### PR TITLE
Fix: 이미지 중앙 정렬 #150

### DIFF
--- a/front/src/components/result/index.tsx
+++ b/front/src/components/result/index.tsx
@@ -116,6 +116,7 @@ export const StyledCaptureContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const StyledContainer = styled.section`


### PR DESCRIPTION
|before|after|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/78977003/223965236-d3fd71bd-1ef9-4eca-83f1-8a32d0d4ba27.png" width=200px/>|<img src="https://user-images.githubusercontent.com/78977003/223965230-07d57868-be6d-4e02-930f-643f79c53b0a.png" width=200px/>|

